### PR TITLE
GH security patches, round 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM node:16-bullseye as frontend-builder
+FROM node:16-bullseye AS frontend-builder
 
 # Controls whether to build the frontend assets
 ARG skip_frontend_build
 
 ENV CYPRESS_INSTALL_BINARY=0
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+
+# This codebase's lockfiles are npm v1 and depend on the `sql-formatter` git
+# dependency, which npm 7+ rebuilds from source and fails on. Pin npm 6 (the
+# version node:12 shipped, which this project was authored against).
+RUN npm install --global --force npm@6.14.18
 
 RUN useradd -m -d /frontend redash
 USER redash
@@ -38,6 +43,8 @@ RUN useradd --create-home redash
 # amd64 packages, so msodbcsql17 is installed on amd64 only (production images are amd64;
 # arm64 is for local development, where the MSSQL ODBC runner degrades to disabled).
 # msodbcsql17 (not 18): the mssql_odbc query runner hardcodes "ODBC Driver 17 for SQL Server".
+# libkrb5-dev: needed to build the gssapi wheel (pulled in by phoenixdb 1.2.2 via
+# requests-gssapi; phoenixdb was bumped for protobuf 6 compatibility).
 RUN set -eux; \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -57,6 +64,7 @@ RUN set -eux; \
     default-libmysqlclient-dev \
     freetds-dev \
     libsasl2-dev \
+    libkrb5-dev \
     unzip \
     libsasl2-modules-gssapi-mit \
     ca-certificates && \

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -211,31 +211,63 @@ commits that accompanied each bump. Then go further where safe (gunicorn 22, Jin
   `X-Content-Type-Options: nosniff`, CSP with `frame-ancestors 'none'`); csv/excel runners import
   cleanly at runtime and resolve to `ConfiguredSession`.
 
+### Major-version migration (commit 2) — COMPLETE ✅
+
+Second commit pushed the deps further than the "defer all majors" plan, closing the
+snowflake-capped cluster. Verified: full image build, **732 tests pass**, live `/ping`, in-image
+imports confirm the new versions.
+
+- **cryptography 45.0.7 → 48.0.1**, **pyOpenSSL 25.1.0 → 26.2.0** (unblocked by the snowflake bump;
+  cffi moved to `>=2.0,<3.0`).
+- **snowflake-connector-python 3.18.0 → 4.5.0** (this was the cap holding pyOpenSSL < 26).
+- **google-api-python-client 1.7.11 → 2.190.0**, **protobuf 3.18.3 → 6.33.5** (forced compat bumps:
+  `phoenixdb 0.7 → 1.2.2`, `pydgraph → 25.1.0`, `libkrb5-dev` added to the image). No query-runner
+  code changes were required — BigQuery/Sheets/Analytics runners import and enable.
+- **Build fix (production-critical):** `node:16-bullseye` ships npm 8, which breaks `npm ci` on the
+  `sql-formatter` git dependency — the real production frontend build (`skip_frontend_build` unset)
+  was failing. Pinned **npm 6.14.18** in the Dockerfile builder stage; full image now builds
+  frontend + backend end to end.
+
+### Flask 3 / Werkzeug 3 — attempted, NOT adopted (accepted risk)
+
+Genuinely attempted and rejected on evidence (no code left behind; Flask stays 2.3.2 / Werkzeug 2.3.8):
+Flask 3 hard-requires Flask-SQLAlchemy ≥ 3.0 (FSA 2.5.1 fails to even import under Flask 3), which
+requires SQLAlchemy ≥ 1.4, which breaks the pinned `SQLAlchemy-Utils` (`sort_query`, used by every
+list endpoint's ordering) and `SQLAlchemy-Searchable` (`entity_zero`, the full-text search path). That
+is a pervasive model/search/ordering rewrite on SQLAlchemy 1.4 that **upstream Redash itself has not
+done** (master still ships Flask 2.3.2 / SA 1.3.24). Not worth the app-breakage risk for the residual
+CVEs (see below). This matches upstream's own posture.
+
 ## 5. Final security outcome
 
 | Surface | Before | After |
 |---|---|---|
-| Python (pip-audit, requirements.txt) | 94 vulns / 21 pkgs | **~23 / 6 pkgs** — all residuals hard-blocked (see below) |
-| Python data-source deps | — | 2 residual (protobuf, needs google-client 2.x) |
+| Python (pip-audit, requirements.txt) | 94 vulns / 21 pkgs | **15 / 4 pkgs** — all residuals hard-blocked (see below) |
+| Python data-source deps | (protobuf 3 + certifi) | **2 / 1 pkg** (certifi floor-pin artifact; image installs 2026.x) |
 | Frontend runtime (npm) | viz-lib 18 crit / root 35 crit | viz-lib 11 / root 28 — remainder is **dev-toolchain only** |
 | Redash app CVEs | 1 live (SAML CVE-2021-21239) | **0 live** (pysaml2 7.3.1) |
 | Reachable SSRF gap (csv/excel) | present | **closed** |
 | Base platform | Python 3.7 / Debian Buster (EOL, non-building) | Python 3.10 / Debian Bullseye (supported, builds) |
 | Backend tests | (image didn't build) | **732 pass** + live `/ping` |
 
-**Residual Python findings are all major-migration-blocked, none silent:** cryptography/pyOpenSSL
-(capped by snowflake 3.x's `pyOpenSSL<26`), Flask/Werkzeug (fixes only in 3.x), requests/urllib3
-(bumping breaks advocate's SSRF protection). These are captured as the modernization epic in §3.
+**The 15 residual requirements.txt findings are in exactly 4 packages, all deliberately blocked, none silent:**
+- **flask 2.3.2 (1)** + **werkzeug 2.3.8 (6)** — fixes only exist in the 3.x line; adopting them means
+  the SQLAlchemy 1.4 rewrite above. Held by design (matches upstream master).
+- **requests 2.31.0 (3)** + **urllib3 1.26.20 (5)** — requests 2.32 changed connection handling in a way
+  that **bypasses advocate's SSRF validation hooks**, and urllib3 fixes are 2.x-only (requires requests
+  2.32). Bumping would silently disable the SSRF protection that closes CVE-2021-43780. Held by design
+  until `advocate` is replaced with a maintained SSRF guard.
 
 ### Remaining follow-ups for the team (non-blocking)
 
-1. dompurify 2.x → 3.x (breaking) — the one runtime frontend dep still flagged.
-2. Modernization epic: Flask 3 / Werkzeug 3, snowflake 4 + cryptography 46 + pyOpenSSL 26,
-   google-api-client 2.x + protobuf 4, or swap `advocate` for a maintained SSRF guard to unlock
-   requests/urllib3.
-3. One CI build on **amd64** to confirm the msodbcsql17/Simba ODBC path (local verification was arm64).
-4. `docker-compose.yml` still pins `postgres:9.5` / `redis:3` and an obsolete `version:` key (dev only).
-5. Production config hardening: set `REDASH_ENFORCE_CSRF=true`, `REDASH_ENFORCE_HTTPS=true`, distinct
+1. **Replace `advocate` with a maintained SSRF guard**, then unblock requests 2.32.4 + urllib3 2.x
+   (clears 8 of the 15 residual findings). Biggest remaining win.
+2. dompurify 2.x → 3.x (breaking) — the one runtime frontend dep still flagged.
+3. Flask 3 / Werkzeug 3 (+ SQLAlchemy 1.4/2.0, SQLAlchemy-Utils/Searchable rewrite) — track upstream;
+   revisit if/when upstream Redash does it. Clears the other 7 residual findings.
+4. One CI build on **amd64** to confirm the msodbcsql17/Simba ODBC path (local verification was arm64).
+5. `docker-compose.yml` still pins `postgres:9.5` / `redis:3` and an obsolete `version:` key (dev only).
+6. Production config hardening: set `REDASH_ENFORCE_CSRF=true`, `REDASH_ENFORCE_HTTPS=true`, distinct
    `REDASH_COOKIE_SECRET` vs `REDASH_SECRET_KEY`.
-6. dql/dynamo3 install via `--no-deps` in the Dockerfile — delete that line if the DynamoDB runner
+7. dql/dynamo3 install via `--no-deps` in the Dockerfile — delete that line if the DynamoDB runner
    is unused at Avea.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,14 @@ aniso8601==8.0.0
 # ldap3==2.2.4
 Authlib==1.7.2
 blinker==1.6.2
-# Keep cffi on the 1.x line: snowflake-connector-python (requirements_all_ds.txt)
-# requires cffi<2.0, and this file is installed last so it decides the final version.
-cffi>=1.17.1,<2.0
+# cffi 2.x: cryptography 48.x requires cffi>=2.0. The old <2.0 cap existed for
+# snowflake-connector-python 3.x; snowflake 4.x dropped its cffi dependency entirely,
+# so the cap is no longer needed. This file is installed last, so it decides the final version.
+cffi>=2.0,<3.0
 click==8.1.3
-cryptography==45.0.7
+# 48.0.1 (not upstream v26's 48.0.0): 48.0.0 is still flagged by pip-audit
+# (GHSA-537c-gmf6-5ccf, fixed in 48.0.1); same 48.0.x line, same dependency contract.
+cryptography==48.0.1
 disposable-email-domains>=0.0.52
 Flask==2.3.2
 Flask-Limiter==3.3.1
@@ -34,7 +37,7 @@ parsedatetime==2.4
 passlib==1.7.3
 psycopg2-binary==2.9.6
 PyJWT==2.13.0
-pyOpenSSL==25.1.0
+pyOpenSSL==26.2.0
 # Pin pyparsing to the 2.x line: pyparsing 3.x breaks SQLAlchemy-Searchable 0.10.6.
 # 2.4.7 is the newest 2.x and also satisfies httplib2 (which needs >=2.4.2,<3).
 pyparsing==2.4.7

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -15,8 +15,11 @@ cmem-cmempy==21.2.3
 # dynamo3==0.4.10
 # Pin: 1.0.3+ requires firebolt-sdk>=1.5.0; keep the version the fork has been running.
 firebolt-sqlalchemy==1.0.2
-google-api-python-client==1.7.11
-google-auth>=2.22.0
+# 2.x still ships the `apiclient` shim and accepts oauth2client-authorized
+# httplib2 via build(http=...); bigquery.v2 and analytics.v3 static discovery
+# docs are bundled, so the google query runners work unchanged.
+google-api-python-client==2.190.0
+google-auth>=2.22.0,<3
 gspread==3.1.0
 # ibm_db ships a prebuilt DB2 client driver for x86_64 only.
 ibm-db>=2.0.9; platform_machine == "x86_64"
@@ -31,10 +34,16 @@ openpyxl==3.0.7
 # pandas is needed by the excel/csv query runners (previously pulled in
 # transitively by pymapd, which has been dropped)
 pandas==1.3.4
-phoenixdb==0.7
-protobuf==3.18.3
+# 1.2.2 (upstream v26 pin): phoenixdb 0.7 ships pre-protoc-3.19 generated code that
+# protobuf 6 rejects with a TypeError at import, which escapes the runner's
+# `except ImportError` guard and crashes query-runner loading. 1.2.2 pulls in
+# requests-gssapi/gssapi, which needs libkrb5-dev (added to the Dockerfile).
+phoenixdb==1.2.2
+protobuf==6.33.5
 PyAthena>=1.5.0,<=1.11.5
-pydgraph==2.0.2
+# 25.1.0 (upstream v26 pin): pydgraph 2.0.2's generated code is incompatible with
+# protobuf 6 (TypeError at import, same failure mode as phoenixdb 0.7).
+pydgraph==25.1.0
 pydruid==0.5.7
 pyexasol==0.12.0
 pyhive==0.6.1
@@ -51,7 +60,11 @@ qds-sdk>=1.9.6
 requests_aws_sign==0.1.5
 sasl>=0.1.3
 simple_salesforce==0.74.3
-snowflake-connector-python==3.18.0
+# snowflake 4.x drops the pyOpenSSL<26 cap (and its cffi dependency). It declares
+# requests>=2.32.4, but requests stays pinned at 2.31.0 in requirements.txt (advocate
+# SSRF guard); snowflake vendors its own requests/urllib3, so this is only a pip
+# metadata warning, not a runtime break.
+snowflake-connector-python==4.5.0
 td-client==1.0.0
 thrift==0.16.0
 thrift_sasl>=0.1.0


### PR DESCRIPTION
Security: upgrade Snowflake/Google/crypto cluster; fix prod frontend build

Second-phase upgrades that push past the deferred major versions where it was safe, closing the dependency cluster that snowflake was capping. Verified: full image build, 732 backend tests pass, live /ping returns PONG, in-image imports confirm the new versions.

- cryptography 45.0.7 -> 48.0.1, pyOpenSSL 25.1.0 -> 26.2.0 (cffi -> >=2.0,<3.0)
- snowflake-connector-python 3.18.0 -> 4.5.0 (was capping pyOpenSSL<26)
- google-api-python-client 1.7.11 -> 2.190.0, protobuf 3.18.3 -> 6.33.5 (compat: phoenixdb 0.7 -> 1.2.2, pydgraph -> 25.1.0, libkrb5-dev added). No query-runner code changes needed; BigQuery/Sheets/Analytics import + enable.
- Dockerfile: pin npm 6.14.18 in the node:16 builder. node:16 ships npm 8, which breaks `npm ci` on the sql-formatter git dependency -- the real production frontend build (skip_frontend_build unset) was failing. Now builds end to end.

Flask/Werkzeug intentionally held at 2.3.2/2.3.8: Flask 3 forces Flask-SQLAlchemy 3.x -> SQLAlchemy 1.4+, which breaks SQLAlchemy-Utils (sort_query) and SQLAlchemy-Searchable (full-text search) -- a pervasive rewrite upstream Redash itself has not done. Documented as accepted risk.

pip-audit: requirements.txt now 15 findings / 4 pkgs (flask, werkzeug, requests, urllib3), all hard-blocked (Flask 3 migration; requests 2.32 bypasses advocate SSRF hooks). data-source deps: 2 (certifi floor-pin artifact). See SECURITY_AUDIT.md.

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
